### PR TITLE
feat: add angular material with theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.angular
+

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "@ngrx/effects": "^17.0.0",
     "@ngrx/store": "^17.0.0",
     "@ngrx/store-devtools": "^17.0.0",
+    "@angular/material": "^19.0.0",
+    "@angular/cdk": "^19.0.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.4.0",
     "zone.js": "~0.14.0"
@@ -32,3 +34,4 @@
     "typescript": "5.8.2"
   }
 }
+

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,3 +1,4 @@
-h1 {
-  margin: 0;
+.spacer {
+  flex: 1 1 auto;
 }
+

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,21 +1,25 @@
-<header>
-  <h1 style="margin: 1rem;">{{ title }}</h1>
-  <nav>
-    <a routerLink="/fundamentals" routerLinkActive="active">Fundamentals</a>
-    <a routerLink="/interpolation" routerLinkActive="active">Interpolation &amp; Binding</a>
-    <a routerLink="/event-binding" routerLinkActive="active">Event Binding</a>
-    <a routerLink="/two-way-binding" routerLinkActive="active">Two‑Way Binding</a>
-    <a routerLink="/directive-demo" routerLinkActive="active">Directives</a>
-    <a routerLink="/pipe-demo" routerLinkActive="active">Pipes</a>
-    <a routerLink="/service-demo" routerLinkActive="active">Services</a>
-    <a routerLink="/lifecycle-demo" routerLinkActive="active">Lifecycle</a>
-    <a routerLink="/signals-demo" routerLinkActive="active">Signals</a>
-    <a routerLink="/ngrx-demo" routerLinkActive="active">NgRx Demo</a>
-  </nav>
-</header>
+<mat-toolbar color="primary">
+  <span>{{ title }}</span>
+  <span class="spacer"></span>
+  <mat-slide-toggle (change)="toggleTheme()" [checked]="isDarkTheme">
+    Dark mode
+  </mat-slide-toggle>
+</mat-toolbar>
 
-<!-- The router outlet is where components associated with routes are rendered -->
-<main style="padding: 1rem;">
-  Yes
+<nav>
+  <a mat-button routerLink="/fundamentals" routerLinkActive="active">Fundamentals</a>
+  <a mat-button routerLink="/interpolation" routerLinkActive="active">Interpolation &amp; Binding</a>
+  <a mat-button routerLink="/event-binding" routerLinkActive="active">Event Binding</a>
+  <a mat-button routerLink="/two-way-binding" routerLinkActive="active">Two‑Way Binding</a>
+  <a mat-button routerLink="/directive-demo" routerLinkActive="active">Directives</a>
+  <a mat-button routerLink="/pipe-demo" routerLinkActive="active">Pipes</a>
+  <a mat-button routerLink="/service-demo" routerLinkActive="active">Services</a>
+  <a mat-button routerLink="/lifecycle-demo" routerLinkActive="active">Lifecycle</a>
+  <a mat-button routerLink="/signals-demo" routerLinkActive="active">Signals</a>
+  <a mat-button routerLink="/ngrx-demo" routerLinkActive="active">NgRx Demo</a>
+</nav>
+
+<main style="padding: 1rem;" class="mat-app-background">
   <router-outlet></router-outlet>
 </main>
+

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,8 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 /**
  * The root component of the Angular fundamentals demo.  This component
@@ -10,10 +13,22 @@ import { RouterLink, RouterOutlet } from '@angular/router';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterLink, RouterOutlet],
+  imports: [
+    RouterLink,
+    RouterOutlet,
+    MatToolbarModule,
+    MatButtonModule,
+    MatSlideToggleModule
+  ],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
   title = 'Angular Fundamentals Demo';
+  isDarkTheme = false;
+
+  toggleTheme(): void {
+    this.isDarkTheme = !this.isDarkTheme;
+    document.body.classList.toggle('dark-theme', this.isDarkTheme);
+  }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,8 @@
   <title>Angular Fundamentals Demo</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,7 @@
+import 'zone.js';
 import { bootstrapApplication } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { AppComponent } from './app/app.component';
 import { routes } from './app/app.routes';
 
@@ -9,6 +11,8 @@ import { routes } from './app/app.routes';
 // keep the example simple and dependency free.
 bootstrapApplication(AppComponent, {
   providers: [
-    provideRouter(routes)
+    provideRouter(routes),
+    provideAnimations()
   ]
 }).catch(err => console.error(err));
+

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,6 +1,8 @@
+@import '@angular/material/prebuilt-themes/indigo-pink.css';
+
 /* Global styles for the Angular fundamentals demo */
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: Roboto, Arial, sans-serif;
   margin: 0;
   padding: 0;
   background-color: #f5f5f5;
@@ -19,19 +21,37 @@ a:hover {
 nav {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 0.5rem;
   background-color: #fff;
   border-bottom: 1px solid #e0e0e0;
-  padding: 1rem;
-}
-
-nav a {
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  background-color: #e3f2fd;
+  padding: 0.5rem;
 }
 
 nav a.active {
-  background-color: #bbdefb;
   font-weight: bold;
 }
+
+/* Dark theme overrides */
+body.dark-theme {
+  background-color: #303030;
+  color: #fff;
+  color-scheme: dark;
+}
+
+body.dark-theme a {
+  color: #90caf9;
+}
+
+body.dark-theme nav {
+  background-color: #424242;
+  border-bottom-color: #616161;
+}
+
+body.dark-theme nav a {
+  color: #fff;
+}
+
+body.dark-theme nav a.active {
+  font-weight: bold;
+}
+


### PR DESCRIPTION
## Summary
- include Angular Material dependencies and enable animations
- style app shell with Material toolbar, buttons and dark/light theme toggle
- load Material fonts and ignore Angular build cache

## Testing
- `npm test` (fails: Cannot determine project or target for command.)
- `npm start` (fails: Can't resolve '@angular/material/...')

------
https://chatgpt.com/codex/tasks/task_e_68ae664191a8832c82e33aa3877f0cde